### PR TITLE
test: tolerate non-zero eslint exit in fixtures

### DIFF
--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -117,9 +117,14 @@ export default antfu(
 )
   `);
 
+    // Fixtures intentionally contain code that trips lint rules; some (e.g.
+    // e18e/prefer-static-regex) are not auto-fixable and make eslint exit
+    // non-zero. We only care about the auto-fixed output snapshot, so don't
+    // let a non-zero exit code reject the run.
     await execa("npx", ["eslint", ".", "--fix"], {
       cwd: target,
       stdio: "pipe",
+      reject: false,
     });
 
     const files = await fg("**/*", {


### PR DESCRIPTION
> **Stacked PR**: base は [#1173](https://github.com/shiron-dev/eslint-config/pull/1173)（`fix/relax-pnpm-trust-policy`）。#1173 がマージされたら base を `main` に切り替えます。差分はテスト1ファイルのみ。

## 課題

fixtures テストは `eslint . --fix` を実行し、autofix 後の出力スナップショットを検証します。antfu の新ルール `e18e/prefer-static-regex`（autofix 不可）が fixtures 入力で発火するため eslint が非ゼロ終了し、execa が reject して全 fixture テストが落ちます。

これまで eslint-config の Main CI は pnpm 11 化（#1170）以降 install 段階で落ちており vitest が走っていなかったため、この潜在 fail は #1173 で install が直って初めて表面化しました。trustPolicy 修正とは無関係なので別 PR に分離しています。

## 変更

`execa(...)` に `reject: false` を渡し、eslint の終了コードでテストハーネスを中断させないようにします。autofix 後出力のスナップショット検証はそのまま機能します。

## 検証 (pnpm 11.6.0)

- `pnpm test` → 8/8 passed
- `pnpm lint` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)