### PR TITLE
fix: deploy inspector from dist output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./.eslint-config-inspector --project-name=eslint-config
+          command: pages deploy ./dist/__eslint-config-inspector --project-name=eslint-config
 
   npm-publish:
     needs: release-please


### PR DESCRIPTION
## Summary
- update the release workflow Cloudflare Pages deploy path to the current inspector build output

## Context
- `pnpm run build:inspector` now writes to `dist/__eslint-config-inspector`, while the release workflow still deployed `./.eslint-config-inspector`.